### PR TITLE
Grid to store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+/build

--- a/letscoloring/Move.lock
+++ b/letscoloring/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 2
-manifest_digest = "D7CB33DA8D11069072524F3E6F2A80209C405419BCF763B99878B735E8F131BF"
+manifest_digest = "2F08AE52B5B9F4A40A0D48ED3F683D33559FDF400AFD83E7C13940952720FD07"
 deps_digest = "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082"
 dependencies = [
   { name = "Sui" },
@@ -10,7 +10,7 @@ dependencies = [
 
 [[move.package]]
 name = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "framework/testnet", subdir = "crates\\sui-framework\\packages\\move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "framework/testnet", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 name = "Sui"
@@ -21,6 +21,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.23.0"
+compiler-version = "1.24.1"
 edition = "2024.beta"
 flavor = "sui"

--- a/letscoloring/Move.toml
+++ b/letscoloring/Move.toml
@@ -20,6 +20,7 @@ Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-fram
 
 [addresses]
 letscoloring = "0x0"
+hold = "0xFFFF"
 
 # Named addresses will be accessible in Move as `@name`. They're also exported:
 # for example, `std = "0x1"` is exported by the Standard Library.

--- a/letscoloring/sources/coloring.move
+++ b/letscoloring/sources/coloring.move
@@ -1,170 +1,332 @@
 module letscoloring::coloring{
-    use sui::coin::{Self,Coin};
+    use sui::coin::{Self, Coin};
     use sui::sui::SUI;
     use sui::url::{Url};
     use sui::balance::{Self, Balance};
     use sui::package;
     use sui::display;
-    use std::string::{String,Self};
+    use std::string::{String, Self};
     use sui::url;
-    use sui::table::{Self,Table};
+    use sui::table::{Self, Table};
+    use sui::table_vec::{Self, TableVec};
     
     //Error
-    const ENotEligible:u64 = 1;
-    const EGridAlreadyFilled:u64 = 2;
-    const ENotEnoughToken:u64 =3;
-
-    //Sturct
-    public struct AdminCap has key {
-        id:UID
-    }
+    const EGridAlreadyFilled: u64 = 1;
+    const EOutOfRange: u64 = 2;
+    const EGameEnded: u64 = 3;
 
     public struct COLORING has drop{}
 
-    public struct Game_Manager has key,store{
-        id:UID,
-        game_count:u64,
-        games:vector<address>,
+    public struct GameManager has key, store {
+        id: UID,
+        game_count: u64,
+        games: TableVec<ID>,
     }
 
-    public struct Game has key,store{
-        id:UID,
-        index:u64,
-        payment:u64,
-        grids:vector<Grid>,
-        total_reward:Balance<SUI>,
-        reward_by_ticket:Table<address,Balance<SUI>>,
-        grid_filled_by_ticket:Table<address,address>
+    public struct Game has key, store {
+        id: UID,
+        payment: u64,
+        rows: u64,
+        cols: u64,
+        cnt: u64,
+        grids: vector<vector<Grid>>,
+        total_reward: Balance<SUI>,
+        grid_player: vector<vector<address>>,
     }
 
     public struct Ticket has key {
-        id:UID,
-        name:String,
-        description:String,
-        link:String,
-        url:Url,
+        id: UID,
+        name: String,
+        description: String,
+        link: String,
+        url: Url,
     }
 
     //record ticket info for further activity
-    public struct RecordTicketInfo has key,store{
-        id:UID,
-        users:Table<address,address>,
+    public struct RecordTicketInfo has key, store {
+        id: UID,
+        users: Table<address,ID>,
     }
 
-    public struct Grid has key,store {
-        id:UID,
-        game:address,
-        index:u8,
-        filled:bool,
-        color:String,
+    public struct Grid has copy, store, drop {
+        filled: bool,
+        color: String,
     }    
 
-    fun init(otw:COLORING,ctx:&mut TxContext){
+    fun init(otw: COLORING, ctx: &mut TxContext) {
         let publisher = package::claim(otw,ctx);
         let display = display::new<Ticket>(&publisher,ctx);
-        let gm = Game_Manager {
-            id:object::new(ctx),
-            game_count:0,
-            games:vector::empty()
+        let gm = GameManager {
+            id: object::new(ctx),
+            game_count: 0,
+            games: table_vec::empty<ID>(ctx),
         };
 
         transfer::share_object(RecordTicketInfo{
-            id:object::new(ctx),
-            users:table::new<address,address>(ctx),
+            id: object::new(ctx),
+            users: table::new<address, ID>(ctx),
         });
-        transfer::public_transfer(gm,ctx.sender());
-        transfer::public_transfer(publisher,ctx.sender());
-        transfer::public_transfer(display,ctx.sender());
+        transfer::public_share_object(gm);
+        transfer::public_transfer(publisher, ctx.sender());
+        transfer::public_transfer(display, ctx.sender());
     }
 
-    //Admin
-    public fun start_new_game(gm:&mut Game_Manager,payment:u64,grid_count:u8,ctx:&mut TxContext){
-        
-        let new_game_id = object::new(ctx);
-        let mut grids = vector::empty<Grid>();
-        let mut i:u8 = 0;
-        while(i < grid_count){
+    // Open to start
+    public fun start_new_game(
+        gm: &mut GameManager, 
+        payment: u64, 
+        rows: u64,
+        cols: u64,
+        ctx: &mut TxContext
+    ) {
+        let mut grids_2d = vector::empty<vector<Grid>>();
+        let mut addr_2d = vector::empty<vector<address>>();
+        let mut i = rows;
+
+        let mut grids_1d = vector::empty<Grid>();
+        let mut addr_1d = vector::empty<address>();
+        let mut j = cols;
+        while (j > 0) {
             let grid = Grid {
-                id:object::new(ctx),
-                game:object::uid_to_address(&new_game_id),
-                filled:false,
-                index:i,
-                color: string::utf8(b"255255255")
+                filled: false,
+                color: string::utf8(b"FFFFFF"),
             };
-            vector::push_back(&mut grids, grid);
-            i = i + 1;
+            vector::push_back(&mut grids_1d, grid);
+            vector::push_back(&mut addr_1d, @hold);
+            j = j - 1;
+        };
+        while (i > 0) {
+            vector::push_back(&mut grids_2d, grids_1d);
+            vector::push_back(&mut addr_2d, addr_1d);
+            i = i - 1;
         };
         
        let game = Game {
-            id:new_game_id,
-            index:gm.game_count,
-            payment:payment,
-            grids:grids,
-            total_reward:balance::zero(),
-            reward_by_ticket:table::new<address,Balance<SUI>>(ctx),
-            grid_filled_by_ticket:table::new<address,address>(ctx)
-
+            id: object::new(ctx),
+            payment: payment,
+            rows,
+            cols,
+            cnt: rows * cols,
+            grids: grids_2d,
+            total_reward: balance::zero(),
+            grid_player: addr_2d,
         };
 
-        gm.game_count = gm.game_count+1;
-        vector::push_back(&mut gm.games,object::uid_to_address(&game.id));
-
+        gm.game_count = gm.game_count + 1;
+        table_vec::push_back<ID>(&mut gm.games, object::id(&game));
         transfer::share_object(game);
     }
-    //User
-    #[allow(lint(self_transfer))]
-    public fun claim_all_by_tickt(ticket:&Ticket,game:&mut Game,ctx:&mut TxContext){
-        //check weather ticke is match game
-        assert!(table::contains(&game.reward_by_ticket,object::uid_to_address(&ticket.id)),ENotEligible);
-        let reward_balance = table::remove(&mut game.reward_by_ticket,object::uid_to_address(&ticket.id));
-        let coin = coin::from_balance<SUI>(reward_balance,ctx);
-        transfer::public_transfer(coin,ctx.sender());
+
+    public fun get_player(game: &Game, row: u64, col: u64): address {
+        assert!(row < game.rows && col < game.cols, EOutOfRange);
+        let tg_row = vector::borrow<vector<address>>(&game.grid_player, row);
+        let tg_player = vector::borrow<address>(tg_row, col);
+        *tg_player
+    }
+
+    fun set_player(game: &mut Game, row: u64, col: u64, ctx: &TxContext) {
+        assert!(row < game.rows && col < game.cols, EOutOfRange);
+        let tg_row = vector::borrow_mut<vector<address>>(&mut game.grid_player, row);
+        let tg_player = vector::borrow_mut<address>(tg_row, col);
+        *tg_player = ctx.sender();
+    }
+
+    public fun borrow_grid(game: &Game, row: u64, col: u64): &Grid {
+        assert!(row < game.rows && col < game.cols, EOutOfRange);
+        let tg_row = vector::borrow<vector<Grid>>(&game.grids, row);
+        let tg_grid = vector::borrow<Grid>(tg_row, col);
+        tg_grid
+    }
+
+    public fun get_grid_filled(grid: &Grid): bool {
+        grid.filled
+    }
+
+    public fun get_grid_color(grid: &Grid): String {
+        grid.color
+    }
+
+    public fun borrow_mut_grid(game: &mut Game, row: u64, col: u64): &mut Grid {
+        assert!(row < game.rows && col < game.cols, EOutOfRange);
+        let tg_row = vector::borrow_mut<vector<Grid>>(&mut game.grids, row);
+        let tg_grid = vector::borrow_mut<Grid>(tg_row, col);
+        tg_grid
+    }
+
+    fun set_grid_filled(grid: &mut Grid) {
+        grid.filled = true;
+    }
+
+    fun set_grid_color(grid: &mut Grid, color: String) {
+        grid.color = color;
     }
 
     public fun fill_grid(
-    game:&mut Game,
-    grid:&Grid,
-    token:&mut Coin<SUI>,
-    new_color:vector<u8>,
-    ticket_info:&mut RecordTicketInfo,
-    ctx:&mut TxContext){
+        game: &mut Game,
+        token: &mut Coin<SUI>,
+        row: u64,
+        col: u64,
+        new_color: vector<u8>,
+        ticket_info:&mut RecordTicketInfo,
+        ctx:&mut TxContext
+    ) {
         let sender = ctx.sender();
         //if ticket is not exsist,creat a new ticket and transfer to sender
-        if(!table::contains(&ticket_info.users,sender)){
-            let ticket = creat_ticket(ticket_info,ctx);            
-            transfer::transfer(ticket,sender);
+        if(!table::contains(&ticket_info.users, sender)){
+            let ticket = creat_ticket(ticket_info, ctx);            
+            transfer::transfer(ticket, sender);
         };
-        payment(game,token,ctx);
-        let filled_grid_address = change_grid_color(game,grid,new_color);
-        table::add(&mut game.grid_filled_by_ticket,sender,filled_grid_address);
+        assert!(game.cnt > 0, EGameEnded);
+        assert!(row < game.rows && col < game.cols, EOutOfRange);
+        let grid_b = borrow_grid(game, row, col);
+        assert!(!get_grid_filled(grid_b), EGridAlreadyFilled);
+
+        let game_coin = coin::split(token, game.payment, ctx);
+        balance::join<SUI>(&mut game.total_reward, coin::into_balance(game_coin));
+
+        let grid_bm = borrow_mut_grid(game, row, col);
+        set_grid_filled(grid_bm);
+        set_grid_color(grid_bm, string::utf8(new_color));
+        set_player(game, row, col, ctx);
     }
 
-    fun payment(game:&mut Game,token:&mut Coin<SUI>,ctx:&mut TxContext){
-        let value = coin::value(token);
-        assert!(value>game.payment,ENotEnoughToken);
-        let game_coin = coin::split(token, game.payment,ctx);
-        balance::join<SUI>(&mut game.total_reward,coin::into_balance(game_coin));
-    }
-
-    fun creat_ticket(ticket_info:&mut RecordTicketInfo,ctx:&mut TxContext):Ticket{
+    fun creat_ticket(ticket_info: &mut RecordTicketInfo, ctx: &mut TxContext): Ticket {
         let ticket = Ticket{
-            id:object::new(ctx),
-            name:string::utf8(b"Let's Coloring Ticket"),
+            id: object::new(ctx),
+            name: string::utf8(b"Let's Coloring Ticket"),
             description:string::utf8(b"Early-stage activity for NexTheater"),
             link:string::utf8(b"https://nextheater.xyz"),
             url:url::new_unsafe_from_bytes(b"https://blush-left-firefly-321.mypinata.cloud/ipfs/QmbLCxFoe9E55vgB9m4HFYeq1rxYa3wm5RDKY3tKSPwXc4"),
         };
-        table::add(&mut ticket_info.users,ctx.sender(),object::uid_to_address(&ticket.id));            
+        table::add(&mut ticket_info.users, ctx.sender(), object::id(&ticket));            
         ticket
     }
 
-    //gaming
-    fun change_grid_color(game:&mut Game,grid:&Grid,new_color:vector<u8>):address{
-        assert!(object::uid_to_address(&game.id) == grid.game, ENotEligible);
-        assert!(!grid.filled, EGridAlreadyFilled);
-        let game_grid = vector::borrow_mut(&mut game.grids,grid.index as u64);
-        game_grid.color = string::utf8(new_color);
-        object::uid_to_address(&game_grid.id)
+    #[allow(lint(self_transfer))]
+    public fun settlement(game: &mut Game, ctx: &mut TxContext) {
+        let rows = game.rows;
+        let cols = game.cols;
+
+        let mut color_type = vector::empty<String>();
+        let mut color_cnt = table::new<String, u64>(ctx);
+
+        let mut i = 0;
+        let mut j = 0;
+
+        while(i < rows) {
+            while(j < cols) {
+                let grid_b = borrow_grid(game, i, j);
+                let color = get_grid_color(grid_b);
+                if (!table::contains<String, u64>(&color_cnt, color)) {
+                    vector::push_back(&mut color_type, color);
+                    table::add<String, u64>(&mut color_cnt, color, 1);
+                } else {
+                    let cnt = table::borrow_mut<String, u64>(&mut color_cnt, color);
+                    *cnt = *cnt + 1;
+                };
+                j = j + 1;
+            };
+            i = i + 1;
+        };
+
+        let mut color_max = color_type[0];
+        let mut color_min = color_type[0];
+        let mut color_max_cnt = *table::borrow<String, u64>(&color_cnt, color_max);
+        let mut color_min_cnt = *table::borrow<String, u64>(&color_cnt, color_min);
+
+        i = 0;
+        let mut len = color_type.length();
+        while (i < len) {
+            let cur_color = color_type[i];
+            let cur_color_cnt = *table::borrow<String, u64>(&color_cnt, cur_color);
+            if (cur_color_cnt > color_max_cnt) {
+                color_max_cnt = cur_color_cnt;
+                color_max = cur_color;
+            };
+            if (cur_color_cnt < color_min_cnt) {
+                color_min_cnt = cur_color_cnt;
+                color_min = cur_color;
+            };
+            i = i + 1;
+        };
+
+        let mut max_color_player_cnt = table::new<address, u64>(ctx);
+        let mut min_color_player_cnt = table::new<address, u64>(ctx);
+
+        let mut max_player_vec = vector::empty<address>();
+        let mut min_player_vec = vector::empty<address>();
+
+        let mut max_player_cnt = 0;
+        let mut min_player_cnt = 0;
+
+        i = 0;
+        j = 0;
+
+        while (i < rows) {
+            while (j < cols) {
+                let grid_b = borrow_grid(game, i, j);
+                let color = get_grid_color(grid_b);
+                if (color == color_max) {
+                    let player = get_player(game, i, j);
+                    if (!table::contains<address, u64>(&max_color_player_cnt, player)) {
+                        vector::push_back(&mut max_player_vec, player);
+                        table::add<address, u64>(&mut max_color_player_cnt, player, 1);
+                    } else {
+                        let player_cnt = table::borrow_mut<address, u64>(&mut max_color_player_cnt, player);
+                        *player_cnt = *player_cnt + 1;
+                    };
+                    max_player_cnt = max_player_cnt + 1;
+                };
+                if (color == color_min) {
+                    let player = get_player(game, i, j);
+                    if (!table::contains<address, u64>(&min_color_player_cnt, player)) {
+                        vector::push_back(&mut min_player_vec, player);
+                        table::add<address, u64>(&mut min_color_player_cnt, player, 1);
+                    } else {
+                        let player_cnt = table::borrow_mut<address, u64>(&mut min_color_player_cnt, player);
+                        *player_cnt = *player_cnt + 1;
+                    };
+                    min_player_cnt = min_player_cnt + 1;
+                };
+                j = j + 1;
+            };
+            i = i + 1;
+        };
+
+        let total_reward = balance::value<SUI>(&game.total_reward);
+
+        len = max_player_vec.length();
+        i = 0;
+        while (i < len) {
+            let player = max_player_vec[i];
+            let cur_player_cnt = *table::borrow<address, u64>(&max_color_player_cnt, player);
+            let reward_value: u64 = total_reward * 7 * cur_player_cnt / (10 * max_player_cnt);
+            let reward = coin::take<SUI>(&mut game.total_reward, reward_value, ctx);
+            transfer::public_transfer(reward, player);
+            i = i + 1;
+        };
+
+        len = min_player_vec.length();
+        i = 0;
+        while (i < len) {
+            let player = min_player_vec[i];
+            let cur_player_cnt = *table::borrow<address, u64>(&min_color_player_cnt, player);
+            let reward_value: u64 = total_reward * 3 * cur_player_cnt / (10 * min_player_cnt);
+            let reward = coin::take<SUI>(&mut game.total_reward, reward_value, ctx);
+            transfer::public_transfer(reward, player);
+            i = i + 1;
+        };
+
+        let remain_value = balance::value<SUI>(&game.total_reward);
+        let reward = coin::take<SUI>(&mut game.total_reward, remain_value, ctx);
+        transfer::public_transfer(reward, ctx.sender());
+
+        game.grids = vector::empty<vector<Grid>>();
+        game.grid_player = vector::empty<vector<address>>();
+
+        table::drop<String, u64>(color_cnt);
+        table::drop<address, u64>(max_color_player_cnt);
+        table::drop<address, u64>(min_color_player_cnt);
     }
 
     //test


### PR DESCRIPTION
做了一些数据格式的重新设计
`Grid` 变为 `copy, store, drop` 作为子项目存储于 `Game` 当中，减少从属映射关系的维护。
添加了清算功能。全部 u64 运算，因为参与玩家数量不多。